### PR TITLE
Add dev container for Java

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,14 @@
+# Environment variables for Java application
+
+# Java Home
+JAVA_HOME=/usr/local/openjdk-23
+
+# Application port
+APP_PORT=8080
+
+# Database configuration
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=mydatabase
+DB_USER=myuser
+DB_PASSWORD=mypassword

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use the official OpenJDK image as the base image
+FROM openjdk:23-jdk-slim-bookworm
+
+# Set the working directory
+WORKDIR /workspace
+
+# Install Maven
+RUN apt-get update && \
+    apt-get install -y maven && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the current directory contents into the container at /workspace
+COPY . /workspace
+
+# Set JAVA_HOME environment variable
+ENV JAVA_HOME /usr/local/openjdk-23
+
+# Expose port 8080
+EXPOSE 8080
+
+# Set user to vscode to avoid using root user
+USER vscode
+
+# Define the command to run the application
+CMD ["mvn", "spring-boot:run"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  java:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/workspace
+    environment:
+      - JAVA_HOME=/usr/local/openjdk-23
+    ports:
+      - "8080:8080"
+    user: vscode

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Java Dev Container",
+  "dockerComposeFile": "compose.yaml",
+  "service": "java",
+  "workspaceFolder": "/workspace",
+  "settings": {
+    "java.home": "/usr/local/openjdk-11",
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.format.settings.url": ".vscode/java-formatter.xml",
+    "java.format.settings.profile": "GoogleStyle"
+  },
+  "extensions": [
+    "vscjava.vscode-java-pack",
+    "redhat.java",
+    "vscjava.vscode-maven",
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test"
+  ],
+  "postCreateCommand": "mvn clean install",
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
Fixes #1

Add Dev Container configuration for Java application development.

* **devcontainer.json**: Add configurations for Java development environment, specify Docker Compose file `compose.yaml`, define settings for VS Code extensions and features, set `"remoteUser": "vscode"`.
* **compose.yaml**: Define services required for the Java application, include configurations for the Java development environment, set user to `vscode`.
* **Dockerfile**: Use `openjdk:23-jdk-slim-bookworm` as base image, install necessary tools and dependencies for Java development, set user to `vscode`, set environment variable `JAVA_HOME=/usr/local/openjdk-23`.
* **.env**: Add environment variables required for the Java application, include necessary configurations for the development environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/ghcp-handson-java/issues/1?shareId=2243af90-afa0-4ebc-af1e-bbd30c43ed68).